### PR TITLE
Fix error for missing name attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "tools"
 maintainer       "Mikhail Pobolovets"
 maintainer_email "styx.mp@gmail.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Now the name attribute is mandatory while you are provisioning the virtual machine with Cheffile+cookbooks
